### PR TITLE
fix:add language for accessibility and lighthouse

### DIFF
--- a/bun/jsx.tsx
+++ b/bun/jsx.tsx
@@ -5,7 +5,7 @@ const app = new Hono()
 
 const Layout = (props: { children?: string }) => {
   return (
-    <html>
+    <html lang="en">
       <body>{props.children}</body>
     </html>
   )

--- a/deno/jsx.tsx
+++ b/deno/jsx.tsx
@@ -20,7 +20,7 @@ type Props = {
 }
 
 const Layout = (props: Props) => html`<!DOCTYPE html>
-  <html>
+  <html lang="en">
     <head>
       <title>${props.title}</title>
     </head>

--- a/jsx-ssr/src/components/Layout.tsx
+++ b/jsx-ssr/src/components/Layout.tsx
@@ -2,7 +2,7 @@ import { html } from 'hono/html'
 
 export const Layout = (props: { title: string; children?: any }) => {
   return html` <!DOCTYPE html>
-    <html>
+    <html lang="en">
       <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/pages/pages/index.html
+++ b/pages/pages/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head></head>
   <body>
     <h1>Hello Pages!!</h1>

--- a/serve-static/assets/static/demo/index.html
+++ b/serve-static/assets/static/demo/index.html
@@ -1,4 +1,4 @@
-<html>
+<html lang="en">
   <body>
     <h1>Hello Hono!</h1>
     <img src="/static/images/dinotocat.png" alt="Dinotocat" />

--- a/validator/src/index.tsx
+++ b/validator/src/index.tsx
@@ -12,7 +12,7 @@ type Post = {
 const posts: Post[] = []
 
 const Layout = (props: any) => html`<!DOCTYPE html>
-  <html>
+  <html lang="en">
     <head>
       <title>Hono Validator Middleware Example</title>
       <link rel="stylesheet" href="https://unpkg.com/@picocss/pico@latest/css/pico.min.css" />


### PR DESCRIPTION
Each of the html templates needs to include the language property for accessibility and best Lighthouse scores.

I've added them so a developer will not forget to do so.

I've defaulted them to English, but the developer can modify as necessary.