### PR TITLE
Fix/remove turbo reference

### DIFF
--- a/bun/jsx.tsx
+++ b/bun/jsx.tsx
@@ -35,4 +35,7 @@ app.get('/', (c) => {
 const port = parseInt(process.env.PORT!) || 3000
 console.log(`Running at http://localhost:${port}`)
 
-export default app
+export default {
+  port,
+  fetch: app.fetch
+};

--- a/bun/tsconfig.json
+++ b/bun/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
-    "jsx": "react-jsx",
+    "jsx": "preserve",
+    "jsxFactory": "jsx",
     "jsxFragmentFactory": "Fragment",
     "jsxImportSource": "hono/jsx"
   }

--- a/jsx-ssr/src/components/Layout.tsx
+++ b/jsx-ssr/src/components/Layout.tsx
@@ -1,15 +1,15 @@
 import { html } from 'hono/html'
 
 export const Layout = (props: { title: string; children?: any }) => {
-  return html` <!DOCTYPE html>
+  return html`<!DOCTYPE html>
     <html>
       <head>
-        <meta charset="UTF-8" />
-        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>${props.title}</title>
         <link
           rel="stylesheet"
-          href="//cdnjs.cloudflare.com/ajax/libs/mini.css/3.0.1/mini-default.min.css"
+          href="https://cdnjs.cloudflare.com/ajax/libs/mini.css/3.0.1/mini-default.min.css"
         />
       </head>
       <body style="padding: 1em 2em">
@@ -18,9 +18,9 @@ export const Layout = (props: { title: string; children?: any }) => {
             <a href="/">Hono Example</a>
           </h1>
         </header>
-        <turbo-frame id="main"> ${props.children} </turbo-frame>
+        ${props.children}
         <footer>
-          <address>Built with <a href="https://github.com/honojs/hono">Hono</a></address>
+          <p>Built with <a href="https://github.com/honojs/hono">Hono</a></p>
         </footer>
       </body>
     </html>`


### PR DESCRIPTION
- remove invalid `turbo-frame` element
- The use of `address` element is better a a plain `p`
- self-closing html isn't a requirement of HTML5 (file size is smaller without it)
- safer to force HTTPS esp. on 3rd party resources