### PR TITLE
docs: replace npm with yarn

### DIFF
--- a/nextjs-stack/README.md
+++ b/nextjs-stack/README.md
@@ -11,7 +11,7 @@
 
 ```
 yarn
-yarn run dev
+yarn dev
 ```
 
 ## Author

--- a/nextjs-stack/README.md
+++ b/nextjs-stack/README.md
@@ -10,8 +10,8 @@
 ## Usage
 
 ```
-npm install
-npm run dev
+yarn
+yarn run dev
 ```
 
 ## Author

--- a/pages-stack/README.md
+++ b/pages-stack/README.md
@@ -11,7 +11,7 @@
 
 ```
 yarn
-yarn run dev
+yarn dev
 ```
 
 ## Author

--- a/pages-stack/README.md
+++ b/pages-stack/README.md
@@ -10,8 +10,8 @@
 ## Usage
 
 ```
-npm install
-npm run dev
+yarn
+yarn run dev
 ```
 
 ## Author


### PR DESCRIPTION
Thanks for your work on Hono!

In the `pages-stack` example, I noticed that `npm install` then `npm run dev` doesn't work. It throws the following error:

```
[proxy]: Internal Error: hono-examples@workspace:.: This package doesn't seem to be present in your lockfile; run "yarn install" to update the lockfile
    at nF.getCandidates (/Users/max/.node/corepack/yarn/3.2.1/yarn.js:438:4480)
    at Bd.getCandidates (/Users/max/.node/corepack/yarn/3.2.1/yarn.js:396:1281)
    at /Users/max/.node/corepack/yarn/3.2.1/yarn.js:442:7764
    at Rg (/Users/max/.node/corepack/yarn/3.2.1/yarn.js:395:11098)
    at le (/Users/max/.node/corepack/yarn/3.2.1/yarn.js:442:7744)

✘ [ERROR] Proxy exited with status 1.
```

From the package.json, it looks like the package manager is suppose to be `yarn` not `npm`.

`npm run dev` works fine in `nextjs-stack`, but if the workspace config is to use `yarn`, then it should use `yarn` not `npm`.