### PR TITLE
Remove body-based title tag in jsx-ssr example

### DIFF
--- a/jsx-ssr/src/pages/page.tsx
+++ b/jsx-ssr/src/pages/page.tsx
@@ -4,7 +4,6 @@ import type { Post } from '../index'
 export const Page = (props: { post: Post }) => {
   return (
     <Layout title={props.post.title}>
-      <title>{props.post.title}</title>
       <main>
         <h2>{props.post.title}</h2>
         <p>{props.post.body}</p>


### PR DESCRIPTION
There is a title tag that gets rendered to the body of the layout which shouldn't be there as title tags are supposedly only useful in the head of a document.