### PR TITLE
Remove invalid workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,6 @@
     "blog",
     "durable-objects",
     "jsx-ssr",
-    "mustache-template",
-    "serve-static",
     "bun",
     "pages-stack",
     "nextjs-stack",


### PR DESCRIPTION
# Summary

I get the following error when running the project with deno

```
> deno serve --parallel jsx.tsx
error: Could not find package.json for workspace member in 'file:///Users/fyaacob/project/personal/hono-examples/mustache-template/'.
```

This is because there's no `mustache-template` and `serve-static` dir in the repo.

This PR removes them from the workspaces list.