### PR TITLE
Add name to package.json for nextjs-stack example

### DIFF
--- a/nextjs-stack/package.json
+++ b/nextjs-stack/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "nextjs-stack",
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
Running `bun i` would fail because the `nextjs-stack` example didn't have a name in its `package.json` file