### PR TITLE
Add start command for prod

### DIFF
--- a/hono-vite-jsx/package.json
+++ b/hono-vite-jsx/package.json
@@ -3,7 +3,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build --mode client && vite build"
+    "build": "vite build --mode client && vite build",
+    "start": "(cd ./dist && node ./index.js)"
   },
   "dependencies": {
     "@hono/node-server": "^1.12.2",


### PR DESCRIPTION
It took me some time to figure out how to run the `dist` build in production. I was also receiving 404's when using `node ./dist/index.js`. Once I `cd`'d into the `dist` directory it worked.

Adding a `start` script to `package.json` would help others trying out this example.